### PR TITLE
Upgrade deprecated runtime nodejs6.10

### DIFF
--- a/cloudformation/config-helper.template
+++ b/cloudformation/config-helper.template
@@ -56,7 +56,7 @@
             "};"
           ]]}
         },
-        "Runtime": "nodejs6.10",
+        "Runtime": "nodejs10.x",
         "Timeout": "30"
       }
     },

--- a/cloudformation/mobile-backend.template
+++ b/cloudformation/mobile-backend.template
@@ -89,7 +89,7 @@
             }, "upload-note.zip"]]
           }
         },
-        "Runtime": "nodejs6.10",
+        "Runtime": "nodejs10.x",
         "Description": "Handles posting notes via API Gateway",
         "Handler": "index.handler",
         "Role": {
@@ -110,7 +110,7 @@
             }, "search.zip"]]
           }
         },
-        "Runtime": "nodejs6.10",
+        "Runtime": "nodejs10.x",
         "Description": "Enables searching notes using CloudSearch domain.",
         "Handler": "index.handler",
         "Role": {
@@ -132,7 +132,7 @@
             }, "stream-handler.zip"]]
           }
         },
-        "Runtime": "nodejs6.10",
+        "Runtime": "nodejs10.x",
         "Description": "Handles posted notes and indexes them in CloudSearch domain.",
         "Handler": "index.handler",
         "Role": {


### PR DESCRIPTION
CloudFormation templates in lambda-refarch-mobilebackend have been found to include a [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs6.10). The affected templates have been updated to a supported runtime (nodejs10.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.